### PR TITLE
sync/lib.sh: pkg_tool=yum when on RHEL-6 please

### DIFF
--- a/sync/lib.sh
+++ b/sync/lib.sh
@@ -730,7 +730,7 @@ function syncLibraryLoaded {
     rlImport "distribution/sync-internal"
 
     # Check package requirements.
-    if rlIsRHEL "7"; then
+    if rlIsRHEL "<=7"; then
         pkg_tool="yum"
     else
         pkg_tool="dnf"


### PR DESCRIPTION
Tests using this library now fail on rhel-6 due to the use of `dnf` instead of `yum`.